### PR TITLE
Add new unit tests

### DIFF
--- a/package/__tests__/Connection.test.js
+++ b/package/__tests__/Connection.test.js
@@ -1,0 +1,13 @@
+import { Connection } from '../classes/Connection.js';
+
+describe('Connection', () => {
+  test('stores constructor parameters', () => {
+    const node1 = { id: 'a' };
+    const node2 = { id: 'b' };
+    const c = new Connection(node1, node2, 'provider', 'accepted');
+    expect(c.node1).toBe(node1);
+    expect(c.node2).toBe(node2);
+    expect(c.type).toBe('provider');
+    expect(c.state).toBe('accepted');
+  });
+});

--- a/package/__tests__/NetworkMetricsExtractor.test.js
+++ b/package/__tests__/NetworkMetricsExtractor.test.js
@@ -1,0 +1,20 @@
+import { extractNetworkMetrics } from '../utility/NetworkMetricsExtractor.js';
+
+describe('extractNetworkMetrics', () => {
+  const originalNavigator = global.navigator;
+
+  afterEach(() => {
+    global.navigator = originalNavigator;
+  });
+
+  test('reads connection values from navigator', async () => {
+    global.navigator = {
+      connection: { downlink: 0.5, upload: 0.2, effectiveType: '4g' },
+    };
+    const metrics = await extractNetworkMetrics();
+    expect(metrics.downloadSpeedKbps).toBe(500);
+    expect(metrics.uploadSpeedKbps).toBe(200);
+    expect(metrics.maxAudioOutputs).toBe(3);
+    expect(metrics.networkConnectionType).toBe('4g');
+  });
+});

--- a/package/__tests__/NostrChannel.test.js
+++ b/package/__tests__/NostrChannel.test.js
@@ -1,0 +1,51 @@
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('nostr-tools', () => ({
+  __esModule: true,
+  Event: class {},
+  SimplePool: class {
+    publish() {}
+    subscribeMany() {}
+    querySync() { return []; }
+  },
+  generateSecretKey: jest.fn(),
+  getPublicKey: jest.fn(),
+  finalizeEvent: jest.fn(e => e),
+}));
+
+const { nostrChannel } = await import('../classes/NostrChannel.js');
+
+describe('nostrChannel basic events', () => {
+  beforeEach(() => {
+    nostrChannel.relays = ['wss://relay'];
+    nostrChannel.profile = { publicKey: 'myKey' };
+  });
+
+  test('sendOffer forwards event to _sendEvent', async () => {
+    const peer = { publicKey: 'peer', space: { id: 'space', host: { publicKey: 'host' } } };
+    const spy = jest.spyOn(nostrChannel, '_sendEvent').mockResolvedValue();
+    await nostrChannel.sendOffer(peer, 'offer');
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({
+      pubkey: 'myKey',
+      kind: 21102,
+    }));
+    spy.mockRestore();
+  });
+
+  test('sendAnswer forwards event to _sendEvent', async () => {
+    const peer = { publicKey: 'peer', space: { id: 'space', host: { publicKey: 'host' } } };
+    const spy = jest.spyOn(nostrChannel, '_sendEvent').mockResolvedValue();
+    await nostrChannel.sendAnswer(peer, 'answer');
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({
+      pubkey: 'myKey',
+      kind: 21103,
+    }));
+    spy.mockRestore();
+  });
+
+  test('isOpen reflects profile and relay status', () => {
+    expect(nostrChannel.isOpen()).toEqual({ publicKey: 'myKey' });
+    nostrChannel.relays = null;
+    expect(nostrChannel.isOpen()).toBeFalsy();
+  });
+});

--- a/package/__tests__/Peer.test.js
+++ b/package/__tests__/Peer.test.js
@@ -1,0 +1,79 @@
+import { jest } from "@jest/globals";
+import { Peer } from '../classes/Peer.js';
+
+function defaultSpace() {
+  return {
+    audioProviderNode: () => false,
+    dropRemoteAudio: jest.fn(),
+  };
+}
+
+function createPeer(opts = {}) {
+  const space = opts.space || defaultSpace();
+  const metrics = opts.metrics || { maxAudioOutputs: 2, uploadSpeedKbps: 100 };
+  return new Peer(
+    space,
+    'name',
+    'pk',
+    false,
+    false,
+    false,
+    metrics,
+    opts.requestConnectionToPeer || jest.fn(),
+    jest.fn(),
+    jest.fn(),
+    jest.fn()
+  );
+}
+
+describe('Peer basic functionality', () => {
+  test('reserveConnection triggers request', () => {
+    const req = jest.fn();
+    const peer = createPeer({ requestConnectionToPeer: req });
+    peer.reserveConnection();
+    expect(req).toHaveBeenCalledWith(peer);
+  });
+
+  test('toggleMute flips track state', () => {
+    const track = { enabled: true };
+    const peer = createPeer();
+    peer.localStream = { getAudioTracks: () => [track] };
+    peer.toggleMute();
+    expect(track.enabled).toBe(false);
+    peer.toggleMute();
+    expect(track.enabled).toBe(true);
+  });
+
+  test('stopMediaTracks stops tracks', () => {
+    const t1 = { stop: jest.fn() };
+    const t2 = { stop: jest.fn() };
+    const peer = createPeer();
+    peer.localStream = { getTracks: () => [t1, t2] };
+    peer.stopMediaTracks();
+    expect(t1.stop).toHaveBeenCalled();
+    expect(t2.stop).toHaveBeenCalled();
+  });
+
+  test('addSubscriptionCloser stores and closeSubscriptions clears', () => {
+    const peer = createPeer();
+    const closer = { close: jest.fn() };
+    peer.addSubscriptionCloser(closer);
+    expect(peer.subscriptionClosers.length).toBe(1);
+    peer.closeSubscriptions();
+    expect(closer.close).toHaveBeenCalled();
+    expect(peer.subscriptionClosers.length).toBe(0);
+  });
+
+  test('closeChannel closes connection and cleans up', () => {
+    const subCloser = { close: jest.fn() };
+    const peer = createPeer();
+    peer.peerConnection = { close: jest.fn(), connectionState: 'connected' };
+    peer.subscriptionClosers = [subCloser];
+    const track = { stop: jest.fn() };
+    peer.localStream = { getTracks: () => [track] };
+    peer.closeChannel();
+    expect(subCloser.close).toHaveBeenCalled();
+    expect(track.stop).toHaveBeenCalled();
+    expect(peer.peerConnection).toBe(null);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for Connection, Peer, NetworkMetricsExtractor and NostrChannel
- mock nostr-tools for NostrChannel tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68604ee725408324a970091b484501b0